### PR TITLE
Fix bug injected during skeleton port

### DIFF
--- a/obmc/dbuslib/bindings.py
+++ b/obmc/dbuslib/bindings.py
@@ -90,7 +90,7 @@ class DbusProperties(dbus.service.Object):
     @dbus.service.method(
         "org.openbmc.Object.Properties", in_signature='sa{sv}')
     def SetMultiple(self, interface_name, prop_dict):
-        if (interface_name in self.properties):
+        if (interface_name not in self.properties):
             self.properties[interface_name] = {}
 
         value_changed = False


### PR DESCRIPTION
This library method originally came from the skeleton project.
While running pep8 after porting it I injected a logic bug.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/pyphosphor/2)

<!-- Reviewable:end -->
