### PR TITLE
Use standard DBUS naming conventions

### DIFF
--- a/obmc/mapper.py
+++ b/obmc/mapper.py
@@ -19,11 +19,10 @@ import obmc.dbuslib.enums
 import obmc.utils.misc
 import obmc.utils.pathtree
 
-MAPPER_NAME = 'org.openbmc.objectmapper'
-MAPPER_IFACE = MAPPER_NAME + '.ObjectMapper'
-MAPPER_PATH = '/org/openbmc/objectmapper/objectmapper'
-ENUMERATE_IFACE = 'org.openbmc.Object.Enumerate'
-MAPPER_NOT_FOUND = 'org.openbmc.objectmapper.Error.NotFound'
+MAPPER_NAME = 'org.openbmc.ObjectMapper'
+MAPPER_IFACE = MAPPER_NAME
+MAPPER_PATH = '/org/openbmc/ObjectMapper'
+MAPPER_NOT_FOUND = MAPPER_NAME + '.Error.NotFound'
 
 
 class Mapper:


### PR DESCRIPTION
The existing service/iface/object path names were out-of-spec.

busname: org.openbmc.ObjectMapper
iface: org.openbmc.ObjectMapper
path: /org/openbmc/ObjectMapper

Signed-off-by: Brad Bishop bradleyb@fuzziesquirrel.com

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/pyphosphor/5)

<!-- Reviewable:end -->
